### PR TITLE
replace Moose::Exporter for plain Exporter

### DIFF
--- a/lib/Resource/Pack.pm
+++ b/lib/Resource/Pack.pm
@@ -1,5 +1,4 @@
 package Resource::Pack;
-use Moose::Exporter;
 # ABSTRACT: tools for managing application resources
 
 use Bread::Board;
@@ -10,6 +9,12 @@ use Resource::Pack::Dir;
 use Resource::Pack::File;
 use Resource::Pack::Resource;
 use Resource::Pack::URL;
+
+use parent 'Exporter';
+
+our @EXPORT = ( qw/
+    resource file dir url install_to install_from install_as include
+/, @Bread::Board::EXPORT );
 
 =head1 SYNOPSIS
 
@@ -213,12 +218,6 @@ sub install_as ($) {
         }
     }
 }
-
-Moose::Exporter->setup_import_methods(
-    also  => ['Bread::Board'],
-    as_is => [qw(resource file dir url install_to install_from install_as
-                 include)],
-);
 
 =head1 TODO
 


### PR DESCRIPTION
... as the latest version of Bread::Board doesn't
use Moose::Exporter, so the `import( also => ... )`
bit in this module wasn't working anymore.

See https://rt.cpan.org/Public/Bug/Display.html?id=122855